### PR TITLE
Setup inputSession

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.darkrockstudios.texteditor.cursor.DrawCursor
@@ -46,6 +47,16 @@ fun BasicTextEditor(
 	val focusRequester = remember { FocusRequester() }
 	val interactionSource = remember { MutableInteractionSource() }
 	val clipboardManager = LocalClipboardManager.current
+	val textInputService = LocalTextInputService.current
+
+	InputServiceEffect(
+		onStart = {
+			state.establishInputSession(textInputService)
+		},
+		onDispose = {
+			state.destroyInputSession(textInputService)
+		}
+	)
 
 	LaunchedEffect(Unit) {
 		if (enabled) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/InputServiceEffect.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/InputServiceEffect.kt
@@ -1,0 +1,34 @@
+package com.darkrockstudios.texteditor
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+internal fun InputServiceEffect(
+	onStart: () -> Unit,
+	onDispose: () -> Unit,
+	key: Any? = null,
+	lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+) {
+	val lifecycleObserver = remember {
+		LifecycleEventObserver { _, event ->
+			if (event == Lifecycle.Event.ON_START) {
+				onStart()
+			}
+		}
+	}
+
+	DisposableEffect(lifecycleOwner, key) {
+		lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+
+		onDispose {
+			lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+			onDispose()
+		}
+	}
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -759,11 +760,11 @@ class TextEditorState(
 				keyboardType = KeyboardType.Text,
 			),
 			onEditCommand = { editCommands ->
-//					editCommands.forEach {
-//						if (it is CommitTextCommand) {
-//							state.insert(it.text)
-//						}
-//					}
+				editCommands.forEach {
+					if (it is CommitTextCommand) {
+						insertTypedString(it.text)
+					}
+				}
 			},
 			onImeActionPerformed = { action ->
 				println("onImeActionPerformed: $action")

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -9,6 +9,11 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TextInputService
+import androidx.compose.ui.text.input.TextInputSession
 import androidx.compose.ui.unit.Constraints
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.LineWrap
@@ -90,6 +95,8 @@ class TextEditorState(
 
 	val editOperations = editManager.editOperations
 
+	private var inputSession: TextInputSession? = null
+
 	internal fun notifyContentChanged() {
 		_version++
 	}
@@ -110,6 +117,20 @@ class TextEditorState(
 
 	fun updateFocus(focused: Boolean) {
 		isFocused = focused
+
+		if (isFocused) {
+			showKeyboard()
+		} else {
+			hideKeyboard()
+		}
+	}
+
+	fun showKeyboard() {
+		inputSession?.showSoftwareKeyboard()
+	}
+
+	fun hideKeyboard() {
+		inputSession?.hideSoftwareKeyboard()
 	}
 
 	fun insertNewlineAtCursor() {
@@ -724,6 +745,38 @@ class TextEditorState(
 			hash = multiplier * hash + line.hashCode()
 		}
 		return hash
+	}
+
+	fun establishInputSession(textInputService: TextInputService?) {
+		if (inputSession != null) {
+			destroyInputSession(textInputService)
+		}
+
+		inputSession = textInputService?.startInput(
+			value = TextFieldValue(""),
+			imeOptions = ImeOptions(
+				autoCorrect = false,
+				keyboardType = KeyboardType.Text,
+			),
+			onEditCommand = { editCommands ->
+//					editCommands.forEach {
+//						if (it is CommitTextCommand) {
+//							state.insert(it.text)
+//						}
+//					}
+			},
+			onImeActionPerformed = { action ->
+				println("onImeActionPerformed: $action")
+			},
+		)
+	}
+
+	fun destroyInputSession(textInputService: TextInputService?) {
+		inputSession?.apply {
+			hideKeyboard()
+			textInputService?.stopInput(this)
+		}
+		inputSession = null
 	}
 
 	init {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.ImeOptions
@@ -763,6 +764,16 @@ class TextEditorState(
 				editCommands.forEach {
 					if (it is CommitTextCommand) {
 						insertTypedString(it.text)
+
+						// TODO when TextInputSession is replaced, this should probably go away
+						val selection = selector.selection?.let { sel ->
+							TextRange(start = sel.start.char, end = sel.end.char)
+						} ?: TextRange.Zero
+						val value = TextFieldValue(
+							annotatedString = textLines[cursor.position.line],
+							selection = selection
+						)
+						inputSession?.updateState(oldValue = null, newValue = value)
 					}
 				}
 			},

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorStateExt.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorStateExt.kt
@@ -1,0 +1,27 @@
+package com.darkrockstudios.texteditor.state
+
+import androidx.compose.ui.text.AnnotatedString
+
+fun TextEditorState.insertTypedCharacter(char: Char) {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+	}
+	insertCharacterAtCursor(char)
+	selector.clearSelection()
+}
+
+fun TextEditorState.insertTypedString(string: String) {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+	}
+	insertStringAtCursor(string)
+	selector.clearSelection()
+}
+
+fun TextEditorState.insertTypedString(string: AnnotatedString) {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+	}
+	insertStringAtCursor(string)
+	selector.clearSelection()
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorKeyboardInputHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorKeyboardInputHandler.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
 import androidx.compose.ui.platform.ClipboardManager
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.insertTypedCharacter
 import com.darkrockstudios.texteditor.state.moveCursorDown
 import com.darkrockstudios.texteditor.state.moveCursorPageDown
 import com.darkrockstudios.texteditor.state.moveCursorPageUp
@@ -211,11 +212,7 @@ internal fun Modifier.textEditorKeyboardInputHandler(
 				else -> {
 					val char = keyEventToUTF8Character(keyEvent)
 					if (char != null) {
-						if (state.selector.selection != null) {
-							state.selector.deleteSelection()
-						}
-						state.insertCharacterAtCursor(char)
-						state.selector.clearSelection()
+						state.insertTypedCharacter(char)
 						true
 					} else {
 						false

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
@@ -148,6 +148,7 @@ private fun handleSpanInteraction(
 	if (clickType == SpanClickType.PRIMARY_CLICK || clickType == SpanClickType.TAP) {
 		state.cursor.updatePosition(position)
 		state.selector.clearSelection()
+		state.showKeyboard()
 	}
 
 	return if (clickedSpan != null && onSpanClick != null) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
@@ -148,7 +148,6 @@ private fun handleSpanInteraction(
 	if (clickType == SpanClickType.PRIMARY_CLICK || clickType == SpanClickType.TAP) {
 		state.cursor.updatePosition(position)
 		state.selector.clearSelection()
-		state.showKeyboard()
 	}
 
 	return if (clickedSpan != null && onSpanClick != null) {
@@ -167,6 +166,7 @@ private fun Modifier.handleTextInteractions(
 			var didHandlePress = false
 			var longPressJob: Job? = null
 			var didLongPress = false
+			var wasDrag = false
 
 			while (true) {
 				val event = awaitPointerEvent()
@@ -184,6 +184,7 @@ private fun Modifier.handleTextInteractions(
 
 						when (eventChange.type) {
 							PointerType.Touch -> {
+								wasDrag = false
 								didLongPress = false
 								longPressJob = state.scope.launch {
 									delay(500)
@@ -228,6 +229,9 @@ private fun Modifier.handleTextInteractions(
 								SpanClickType.TAP,
 								onSpanClick
 							)
+							if (wasDrag.not()) {
+								state.showKeyboard()
+							}
 						}
 
 						longPressJob?.cancel()
@@ -241,6 +245,7 @@ private fun Modifier.handleTextInteractions(
 					PointerEventType.Move -> {
 						val movement = event.changes.first()
 						if (movement.positionChanged()) {
+							wasDrag = true
 							longPressJob?.cancel()
 							longPressJob = null
 						}

--- a/sampleApp/src/androidMain/kotlin/com/darkrockstudios/texteditor/sample/MainActivity.kt
+++ b/sampleApp/src/androidMain/kotlin/com/darkrockstudios/texteditor/sample/MainActivity.kt
@@ -7,8 +7,11 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,6 +26,7 @@ class MainActivity : ComponentActivity() {
 				Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
 					Box(modifier = Modifier
 						.padding(innerPadding)
+						.windowInsetsPadding(WindowInsets.ime)
 						.background(color = Color.White)) {
 						App()
 					}


### PR DESCRIPTION
Looks like this might work, but it's not quite ideal:
`TextInputSession` is setup to work with `TextFieldValue`.

It really wants to be in full control of the text. But it does solve the problem of show/hide of the keyboard.

I understand now why this was deprecated! `PlatformTextInputModifierNode` should solve the problem, but it seems like it is much more of a pain to setup and deal with.