### PR TITLE
Simpler fix

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/annotatedstring/AnnotatedStringUtils.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/annotatedstring/AnnotatedStringUtils.kt
@@ -1,9 +1,20 @@
 package com.darkrockstudios.texteditor.annotatedstring
 
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 
-internal fun String.toAnnotatedString() = AnnotatedString(this)
+fun String.toAnnotatedString(fontFamily: FontFamily? = null): AnnotatedString {
+	return if (fontFamily != null && fontFamily != FontFamily.Default) {
+		buildAnnotatedString {
+			append(this@toAnnotatedString)
+			addStyle(SpanStyle(fontFamily = fontFamily), 0, length)
+		}
+	} else {
+		AnnotatedString(this)
+	}
+}
 
 internal fun AnnotatedString.subSequence(startIndex: Int = 0, endIndex: Int = length) =
 	subSequence(startIndex = startIndex, endIndex = endIndex)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
@@ -92,7 +92,7 @@ class TextEditorCursorState(
 		// check the end of the previous line
 		if (position.char == 0 && position.line > 0) {
 			val previousLine = position.line - 1
-			val previousLineLength = editorState.textLines[previousLine].length
+			val previousLineLength = editorState.textLines[previousLine].length - 1
 			if (previousLineLength > 0) {
 				val previousPosition = CharLineOffset(previousLine, previousLineLength)
 				styles = editorState.getSpanStylesAtPosition(previousPosition)

--- a/sampleApp/src/commonMain/kotlin/CodeEditorDemoUi.kt
+++ b/sampleApp/src/commonMain/kotlin/CodeEditorDemoUi.kt
@@ -5,11 +5,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import codeeditor.CodeEditor
 import codeeditor.rememberCodeEditorStyle
+import com.darkrockstudios.texteditor.annotatedstring.toAnnotatedString
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.rememberTextEditorState
 
@@ -18,7 +19,11 @@ fun CodeEditorDemoUi(
 	modifier: Modifier = Modifier,
 	navigateTo: (Destination) -> Unit,
 ) {
-	val state: TextEditorState = rememberTextEditorState(AnnotatedString(SAMPLE_CODE))
+	val style = rememberCodeEditorStyle(
+		placeholderText = "Enter code here",
+	)
+	val state: TextEditorState =
+		rememberTextEditorState(SAMPLE_CODE.toAnnotatedString(FontFamily.Monospace))
 
 	LaunchedEffect(Unit) {
 		state.editOperations.collect { operation ->
@@ -39,10 +44,6 @@ fun CodeEditorDemoUi(
 				Text("X")
 			}
 		}
-
-		val style = rememberCodeEditorStyle(
-			placeholderText = "Enter code here",
-		)
 
 		CodeEditor(
 			state = state,


### PR DESCRIPTION
This allows you to set a `FontFamily` when `toAnnotatedString`

And it fixes TextEditorCursorState so that the style is always copied down to new lines.

This is a much smaller and simpler fix for #6 