### PR TITLE
Fix deleting a numbered-list item removing following items (#18)

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
@@ -313,6 +313,18 @@ class RichSpanManager(
 							(end.line == deletionPoint.line && end.char <= deletionPoint.char) -> {
 						updatedSpans.add(span)
 					}
+					// Span is entirely below the joined line — the deleted newline pulls
+					// every following line up by one, so decrement its line index.
+					start.line > nextLineStart.line -> {
+						updatedSpans.add(
+							span.copy(
+								range = TextEditorRange(
+									start = CharLineOffset(start.line - 1, start.char),
+									end = CharLineOffset(end.line - 1, end.char)
+								)
+							)
+						)
+					}
 					// Span is entirely on the second line
 					start.line == nextLineStart.line -> {
 						val newStart = CharLineOffset(

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/OrderedListSerializationTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/OrderedListSerializationTest.kt
@@ -246,6 +246,21 @@ class OrderedListSerializationTest {
 	}
 
 	@Test
+	fun `deleting a middle ordered-list item keeps following items in the list`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("1. one\n2. two\n3. three\n4. four")
+
+		val state = extension.editorState
+		// Merge item 2 into item 1 via a single-newline delete (backspace at col 0
+		// of a same-block line). Items 3 and 4 must keep their spans and renumber.
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+		state.backspaceAtCursor()
+
+		assertEquals(listOf(0, 1, 2), extension.orderedLines())
+		assertEquals("1. onetwo\n2. three\n3. four", extension.exportAsMarkdown())
+	}
+
+	@Test
 	fun `enter on empty ordered-list item exits the list`() = runTest {
 		val extension = createMarkdownExtension()
 		extension.importMarkdown("1. one\n2. \n3. three")


### PR DESCRIPTION
## Summary
Deleting a numbered-list item in the middle dropped every following item from the list.

## Root cause
In `RichSpanManager`'s single-newline delete branch (line merge), spans living **entirely below** the joined line were never re-added to the updated span set and kept stale line indices, so they were dropped. For an ordered list, deleting/merging a middle item removed every following item's `OrderedListSpanStyle`. (The multi-line delete path already decrements following-line offsets via `transformOffset`; only the newline-merge path was broken.)

## Fix
Add the missing case: spans entirely below the joined line have their start/end line index decremented by one to follow the upward shift.

## Tests
- New regression test `deleting a middle ordered-list item keeps following items in the list` (in `markdown.OrderedListSerializationTest`) — fails before, passes after.
- Full suite: `:ComposeTextEditor:desktopTest` — 430 tests, 0 failures.

Fixes #18